### PR TITLE
don't treat non-remote artifactory repos (e.g. cached, local) as missing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
     id 'com.gradle.plugin-publish' version '1.2.1'
-    id 'pl.allegro.tech.build.axion-release' version '1.16.1'
+    id 'pl.allegro.tech.build.axion-release' version '1.17.0'
 }
 
 java {

--- a/src/functionalTest/groovy/co/insecurity/gradle/repository_mirrors/RepositoryMirrorsPluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/co/insecurity/gradle/repository_mirrors/RepositoryMirrorsPluginFunctionalTest.groovy
@@ -262,11 +262,13 @@ class RepositoryMirrorsPluginFunctionalTest extends AbstractFunctionalTest {
                 'bsm4 - http://localhost:8080/artifactory/jcenter',
                 'bsi2 - http://localhost:8080/artifactory/jcenter-ivy',
                 'bsm6 - http://localhost:8080/artifactory/repo1',
+                'bsm7 - http://localhost:8080/artifactory/internal-maven',
                 'pm1 - http://localhost:8080/artifactory/repo1',
                 'pi1 - http://localhost:8080/artifactory/jcenter-ivy',
                 'pm3 - http://localhost:8080/artifactory/repo1',
                 'pi2 - http://localhost:8080/artifactory/jcenter-ivy',
                 'pm4 - http://localhost:8080/artifactory/jcenter',
+                'pi3 - http://localhost:8080/artifactory/internal-ivy',
         ].every {String s ->
             result.output.contains(s)
         }

--- a/src/functionalTest/groovy/co/insecurity/gradle/repository_mirrors/fixtures/RepositoryMirrorsPluginFixture.groovy
+++ b/src/functionalTest/groovy/co/insecurity/gradle/repository_mirrors/fixtures/RepositoryMirrorsPluginFixture.groovy
@@ -36,6 +36,10 @@ final class RepositoryMirrorsPluginFixture {
                         name 'bsm6'
                         url '${ARTIFACTORY_URL}/repo1'
                     }
+                    maven {
+                        name 'bsm7'
+                        url '${ARTIFACTORY_URL}/internal-maven'
+                    }
                 }
             }
         """.stripIndent()
@@ -62,6 +66,10 @@ final class RepositoryMirrorsPluginFixture {
                     url 'https://jcenter.bintray.com/'
                 }
                 jcenter {name 'pm4'}
+                ivy {
+                    name 'pi3'
+                    url '${ARTIFACTORY_URL}/internal-ivy'
+                }
             }
         """.stripIndent()
     }


### PR DESCRIPTION
Previously, since the plugin would only fetch remote Ivy & Maven repo types from artifactory, any configured repositories with URLs pointing to non-remote repo types on the Artifactory server (e.g. local/internal artifact repos) were treated as missing. As a result, when the  extension property was set, the plugin would incorrectly remove any such repositories from the build configuration. This change fixes the bug by ignoring repos without mirrors as long as their repository URL starts with the configured artifactory URL.